### PR TITLE
Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+MANIFEST
+dist/
+*.pyc
+build/
+dxlvtapiservice.egg-info/

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,559 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        unused-wildcard-import,
+        wildcard-import,
+        broad-except,
+        too-few-public-methods,
+        too-many-arguments,
+        missing-docstring,
+        protected-access
+
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+#argument-rgx=
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _,
+           f,
+           fh,
+           logger,
+           running,
+           run_condition,
+           config_dir,
+           logging_config_path,
+           log_formatter,
+           console_handler
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+#method-rgx=
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+#variable-rgx=
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/.pylintrc.samples
+++ b/.pylintrc.samples
@@ -1,0 +1,553 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        invalid-name,
+        wrong-import-position,
+        missing-docstring,
+        wildcard-import,
+        unused-wildcard-import,
+        broad-except,
+        too-few-public-methods,
+        redefined-outer-name,
+        undefined-variable,
+        logging-not-lazy,
+        import-error,
+        similarities
+
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+#argument-rgx=
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _,
+           logger
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+#method-rgx=
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+#variable-rgx=
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ services:
 
 python:
   - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 
 before_install:
   - docker pull opendxl/opendxl-broker
@@ -15,15 +18,15 @@ before_install:
 
 # command to install dependencies
 install:
-  - pip install dxlclient dxlbootstrap
-  - pip install .
+  - pip install .[test]
+  # Install through setup.py should be redundant because of the preceding pip
+  # install. Just doing this to try to catch any high-level errors.
+  - python setup.py install
 
 before_script:
-  - python -m dxlclient provisionconfig dxlclient/test 127.0.0.1 client -u admin -p password
-  - cp dxlclient/test/dxlclient.config dxlclient/test/client_config.cfg
-  - sed -i -e "s/external/unique_broker_id_1/g" -e "/local/d" dxlclient/test/client_config.cfg
-  - cat dxlclient/test/client_config.cfg
+  - python -m dxlclient provisionconfig sample 127.0.0.1 client -u admin -p password
+  - cat sample/dxlclient.config
 
 # command to run tests
 script:
-  - python setup.py install
+  - python setup.py ci

--- a/README
+++ b/README
@@ -24,7 +24,7 @@ For bugs, questions and discussions please use the `GitHub Issues <https://githu
 LICENSE
 -------
 
-Copyright 2017 McAfee LLC
+Copyright 2018 McAfee LLC
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
 License. You may obtain a copy of the License at

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For bugs, questions and discussions please use the [GitHub Issues](https://githu
 
 ## LICENSE
 
-Copyright 2017 McAfee LLC
+Copyright 2018 McAfee LLC
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/clean.py
+++ b/clean.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 from distutils.dir_util import remove_tree
 from shutil import copyfile
@@ -5,7 +7,7 @@ from shutil import copyfile
 
 def clean_dir(src_dir, directory):
     if os.path.exists(directory):
-        print("Cleaning directory: " + directory + "\n")
+        print(("Cleaning directory: " + directory + "\n"))
         for f in os.listdir(directory):
             if not os.path.isdir(os.path.join(directory, f)) and not f.lower().endswith(".py"):
                 os.remove(os.path.join(directory, f))
@@ -24,7 +26,7 @@ SAMPLE_SRC_DIRECTORY = os.path.join(DIST_PY_FILE_LOCATION, "dxlvtapiservice", "_
 
 # Remove the dist directory if it exists
 if os.path.exists(DIST_DIRECTORY):
-    print("Removing dist directory: " + DIST_DIRECTORY + "\n")
+    print(("Removing dist directory: " + DIST_DIRECTORY + "\n"))
     remove_tree(DIST_DIRECTORY, verbose=1)
 
 # Clean the config directory

--- a/clean.py
+++ b/clean.py
@@ -1,18 +1,24 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import os
+# pylint: disable=no-name-in-module, import-error
 from distutils.dir_util import remove_tree
 from shutil import copyfile
 
 
 def clean_dir(src_dir, directory):
     if os.path.exists(directory):
-        print(("Cleaning directory: " + directory + "\n"))
+        print("Cleaning directory: " + directory + "\n")
         for f in os.listdir(directory):
-            if not os.path.isdir(os.path.join(directory, f)) and not f.lower().endswith(".py"):
+            target_file = os.path.join(directory, f)
+            if not os.path.isdir(target_file) \
+                    and not f.lower().endswith(".py"):
                 os.remove(os.path.join(directory, f))
         for f in os.listdir(src_dir):
-            if not os.path.isdir(f) and not(f.lower().endswith(".py") or f.lower().endswith(".pyc")):
+            src_file = os.path.join(src_dir, f)
+            if not os.path.isdir(src_file) and \
+                    not f.lower().endswith(".py") and \
+                    not f.lower().endswith(".pyc"):
                 copyfile(os.path.join(src_dir, f), os.path.join(directory, f))
 
 print("Starting clean.\n")
@@ -21,12 +27,14 @@ DIST_PY_FILE_LOCATION = os.path.dirname(os.path.realpath(__file__))
 DIST_DIRECTORY = os.path.join(DIST_PY_FILE_LOCATION, "dist")
 CONFIG_DIRECTORY = os.path.join(DIST_PY_FILE_LOCATION, "config")
 SAMPLE_DIRECTORY = os.path.join(DIST_PY_FILE_LOCATION, "sample")
-CONFIG_SRC_DIRECTORY = os.path.join(DIST_PY_FILE_LOCATION, "dxlvtapiservice", "_config", "app")
-SAMPLE_SRC_DIRECTORY = os.path.join(DIST_PY_FILE_LOCATION, "dxlvtapiservice", "_config", "sample")
+CONFIG_SRC_DIRECTORY = os.path.join(DIST_PY_FILE_LOCATION, "dxlvtapiservice",
+                                    "_config", "app")
+SAMPLE_SRC_DIRECTORY = os.path.join(DIST_PY_FILE_LOCATION, "dxlvtapiservice",
+                                    "_config", "sample")
 
 # Remove the dist directory if it exists
 if os.path.exists(DIST_DIRECTORY):
-    print(("Removing dist directory: " + DIST_DIRECTORY + "\n"))
+    print("Removing dist directory: " + DIST_DIRECTORY + "\n")
     remove_tree(DIST_DIRECTORY, verbose=1)
 
 # Clean the config directory
@@ -38,7 +46,7 @@ clean_dir(SAMPLE_SRC_DIRECTORY, SAMPLE_DIRECTORY)
 # Clean .pyc files
 print("Cleaning .pyc files")
 for root, dirs, files in os.walk(DIST_PY_FILE_LOCATION):
-    for file in files:
-        full_path = os.path.join(root, file)
+    for source_file in files:
+        full_path = os.path.join(root, source_file)
         if full_path.lower().endswith(".pyc"):
             os.remove(full_path)

--- a/dist.py
+++ b/dist.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import subprocess
 from distutils.dir_util import copy_tree, remove_tree
@@ -42,10 +44,10 @@ SAMPLE_RELEASE_DIR = os.path.join(DIST_DIRECTORY, "sample")
 
 # Remove the dist directory if it exists
 if os.path.exists(DIST_DIRECTORY):
-    print("\nRemoving dist directory: " + DIST_DIRECTORY + "\n")
+    print(("\nRemoving dist directory: " + DIST_DIRECTORY + "\n"))
     remove_tree(DIST_DIRECTORY, verbose=1)
 
-print("\nMaking dist directory: " + DIST_DIRECTORY + "\n")
+print(("\nMaking dist directory: " + DIST_DIRECTORY + "\n"))
 os.makedirs(DIST_DIRECTORY)
 
 print("\nCalling sphinx-apidoc\n")
@@ -104,7 +106,7 @@ copy_tree(os.path.join(DIST_PY_FILE_LOCATION, "config"), DIST_CONFIG_DIRECTORY)
 print("\nCopying sample into dist directory\n")
 copy_tree(os.path.join(DIST_PY_FILE_LOCATION, "sample"), SAMPLE_RELEASE_DIR)
 
-print("\nCopying dist to " + DIST_RELEASE_DIR + "\n")
+print(("\nCopying dist to " + DIST_RELEASE_DIR + "\n"))
 copy_tree(DIST_DIRECTORY, DIST_RELEASE_DIR)
 
 print("\nRemoving build directory\n")
@@ -119,5 +121,5 @@ make_archive(DIST_RELEASE_DIR, "zip", DIST_DIRECTORY, RELEASE_NAME)
 print("\nMaking dist config zip\n")
 make_archive(CONFIG_RELEASE_DIR, "zip", os.path.join(DIST_RELEASE_DIR, "config"))
 
-print("\nRemoving " + DIST_RELEASE_DIR + "\n")
+print(("\nRemoving " + DIST_RELEASE_DIR + "\n"))
 remove_tree(DIST_RELEASE_DIR)

--- a/dist.py
+++ b/dist.py
@@ -44,9 +44,11 @@ subprocess.check_call(["sphinx-apidoc",
                        "--output-dir=" + DIST_DOCTMP_DIR,
                        os.path.join(DIST_PY_FILE_LOCATION, "dxlvtapiservice")])
 
-print("\nCopying conf.py and sdk directory\n")
+print("\nCopying conf.py, docutils.conf, and sdk directory\n")
 copy_file(os.path.join(DIST_PY_FILE_LOCATION, "doc", "conf.py"),
           os.path.join(DIST_DOCTMP_DIR, "conf.py"))
+copy_file(os.path.join(DIST_PY_FILE_LOCATION, "doc", "docutils.conf"),
+          os.path.join(DIST_DOCTMP_DIR, "docutils.conf"))
 copy_tree(os.path.join(DIST_PY_FILE_LOCATION, "doc", "sdk"), DIST_DOCTMP_DIR)
 
 print("\nCalling sphinx-build\n")

--- a/dist.py
+++ b/dist.py
@@ -1,30 +1,16 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import os
+# pylint: disable=no-name-in-module, import-error
 import subprocess
 from distutils.dir_util import copy_tree, remove_tree
 from distutils.file_util import copy_file, move_file
 from distutils.core import run_setup
 from distutils.archive_util import make_archive
-from tempfile import mkstemp
-from shutil import move
+
 
 # Run clean
-import clean
-
-
-def replace(file_path, pattern, subst):
-    # Create temp file
-    fh, abs_path = mkstemp()
-    with open(abs_path,'w') as new_file:
-        with open(file_path) as old_file:
-            for line in old_file:
-                new_file.write(line.replace(pattern, subst))
-    os.close(fh)
-    # Remove original file
-    os.remove(file_path)
-    # Move new file
-    move(abs_path, file_path)
+import clean #pylint: disable=unused-import
 
 print("Starting dist.\n")
 
@@ -44,10 +30,10 @@ SAMPLE_RELEASE_DIR = os.path.join(DIST_DIRECTORY, "sample")
 
 # Remove the dist directory if it exists
 if os.path.exists(DIST_DIRECTORY):
-    print(("\nRemoving dist directory: " + DIST_DIRECTORY + "\n"))
+    print("\nRemoving dist directory: " + DIST_DIRECTORY + "\n")
     remove_tree(DIST_DIRECTORY, verbose=1)
 
-print(("\nMaking dist directory: " + DIST_DIRECTORY + "\n"))
+print("\nMaking dist directory: " + DIST_DIRECTORY + "\n")
 os.makedirs(DIST_DIRECTORY)
 
 print("\nCalling sphinx-apidoc\n")
@@ -59,13 +45,13 @@ subprocess.check_call(["sphinx-apidoc",
                        os.path.join(DIST_PY_FILE_LOCATION, "dxlvtapiservice")])
 
 print("\nCopying conf.py and sdk directory\n")
-copy_file(os.path.join(DIST_PY_FILE_LOCATION, "doc", "conf.py"), os.path.join(DIST_DOCTMP_DIR, "conf.py"))
+copy_file(os.path.join(DIST_PY_FILE_LOCATION, "doc", "conf.py"),
+          os.path.join(DIST_DOCTMP_DIR, "conf.py"))
 copy_tree(os.path.join(DIST_PY_FILE_LOCATION, "doc", "sdk"), DIST_DOCTMP_DIR)
 
 print("\nCalling sphinx-build\n")
-subprocess.check_call(["sphinx-build", "-b", "html", DIST_DOCTMP_DIR, os.path.join(DIST_DIRECTORY, "doc")])
-
-replace(os.path.join(DIST_DIRECTORY, "doc", "_static", "classic.css"), "text-align: justify", "text-align: none")
+subprocess.check_call(["sphinx-build", "-b", "html", DIST_DOCTMP_DIR,
+                       os.path.join(DIST_DIRECTORY, "doc")])
 
 # Delete .doctrees
 remove_tree(os.path.join(os.path.join(DIST_DIRECTORY, "doc"), ".doctrees"), verbose=1)
@@ -86,19 +72,12 @@ run_setup(SETUP_PY,
            "--dist-dir",
            DIST_LIB_DIRECTORY])
 
-print("\nRunning setup.py bdist_egg\n")
-run_setup(SETUP_PY,
-          ["bdist_egg",
-           "--dist-dir",
-           DIST_LIB_DIRECTORY])
-
 print("\nRunning setup.py bdist_wheel\n")
 run_setup(SETUP_PY,
           ["bdist_wheel",
            "--dist-dir",
            DIST_LIB_DIRECTORY,
-           "--python-tag",
-           "py2.7"])
+           "--universal"])
 
 print("\nCopying config into dist directory\n")
 copy_tree(os.path.join(DIST_PY_FILE_LOCATION, "config"), DIST_CONFIG_DIRECTORY)
@@ -106,7 +85,7 @@ copy_tree(os.path.join(DIST_PY_FILE_LOCATION, "config"), DIST_CONFIG_DIRECTORY)
 print("\nCopying sample into dist directory\n")
 copy_tree(os.path.join(DIST_PY_FILE_LOCATION, "sample"), SAMPLE_RELEASE_DIR)
 
-print(("\nCopying dist to " + DIST_RELEASE_DIR + "\n"))
+print("\nCopying dist to " + DIST_RELEASE_DIR + "\n")
 copy_tree(DIST_DIRECTORY, DIST_RELEASE_DIR)
 
 print("\nRemoving build directory\n")
@@ -121,5 +100,5 @@ make_archive(DIST_RELEASE_DIR, "zip", DIST_DIRECTORY, RELEASE_NAME)
 print("\nMaking dist config zip\n")
 make_archive(CONFIG_RELEASE_DIR, "zip", os.path.join(DIST_RELEASE_DIR, "config"))
 
-print(("\nRemoving " + DIST_RELEASE_DIR + "\n"))
+print("\nRemoving " + DIST_RELEASE_DIR + "\n")
 remove_tree(DIST_RELEASE_DIR)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 
+from __future__ import absolute_import
 import sys
 import os
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -63,3 +63,4 @@ autoclass_content = 'both'
 
 modindex_common_prefix = ['dxlvtapiservice.']
 
+html_use_smartypants = False

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,7 +31,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = "VirusTotal API DXL Service"
-copyright = "Copyright 2017, McAfee LLC"
+copyright = "2018, McAfee LLC"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/docutils.conf
+++ b/doc/docutils.conf
@@ -1,0 +1,2 @@
+[parsers]
+smart_quotes = False

--- a/doc/sdk/README.html
+++ b/doc/sdk/README.html
@@ -28,7 +28,7 @@
 		<div class="clearer"></div>
 	</div>
 	<div class="footer">
-		&copy; Copyright 2017, McAfee LLC
-    </div>
+		&copy; Copyright 2018, McAfee LLC
+    </div>s
 </div>
 </body>

--- a/doc/sdk/README.html
+++ b/doc/sdk/README.html
@@ -29,6 +29,6 @@
 	</div>
 	<div class="footer">
 		&copy; Copyright 2018, McAfee LLC
-    </div>s
+    </div>
 </div>
 </body>

--- a/doc/sdk/basicdomainreportexample.rst
+++ b/doc/sdk/basicdomainreportexample.rst
@@ -118,10 +118,10 @@ The majority of the sample code is shown below:
             if res.message_type != Message.MESSAGE_TYPE_ERROR:
                 # Display results
                 res_dict = MessageUtils.json_payload_to_dict(res)
-                print MessageUtils.dict_to_json(res_dict, pretty_print=True)
+                print(MessageUtils.dict_to_json(res_dict, pretty_print=True))
             else:
-                print "Error invoking service with topic '{0}': {1} ({2})".format(
-                    request_topic, res.error_message, res.error_code)
+                print("Error invoking service with topic '{0}': {1} ({2})".format(
+                    request_topic, res.error_message, res.error_code))
 
 
 After connecting to the DXL fabric, a `request message` is created with a topic that targets the "domain report" method

--- a/doc/sdk/basicfilereportexample.rst
+++ b/doc/sdk/basicfilereportexample.rst
@@ -87,10 +87,10 @@ The majority of the sample code is shown below:
             if res.message_type != Message.MESSAGE_TYPE_ERROR:
                 # Display results
                 res_dict = MessageUtils.json_payload_to_dict(res)
-                print MessageUtils.dict_to_json(res_dict, pretty_print=True)
+                print(MessageUtils.dict_to_json(res_dict, pretty_print=True))
             else:
-                print "Error invoking service with topic '{0}': {1} ({2})".format(
-                    request_topic, res.error_message, res.error_code)
+                print("Error invoking service with topic '{0}': {1} ({2})".format(
+                    request_topic, res.error_message, res.error_code))
 
 
 After connecting to the DXL fabric, a `request message` is created with a topic that targets the "file report" method

--- a/doc/sdk/index.rst
+++ b/doc/sdk/index.rst
@@ -27,21 +27,21 @@ Service Methods
 
 File
 
-* `Report <https://github.com/opendxl/opendxl-virustotal-service-python/wiki/Service-Methods#file-report>`_
-* `Rescan <https://github.com/opendxl/opendxl-virustotal-service-python/wiki/Service-Methods#file-rescan>`_
+* `Report <https://github.com/opendxl/opendxl-virustotal-service-python/wiki/Service-Methods#file-report>`__
+* `Rescan <https://github.com/opendxl/opendxl-virustotal-service-python/wiki/Service-Methods#file-rescan>`__
 
 URL
 
-* `Report <https://github.com/opendxl/opendxl-virustotal-service-python/wiki/Service-Methods#url-report>`_
-* `Scan <https://github.com/opendxl/opendxl-virustotal-service-python/wiki/Service-Methods#url-scan>`_
+* `Report <https://github.com/opendxl/opendxl-virustotal-service-python/wiki/Service-Methods#url-report>`__
+* `Scan <https://github.com/opendxl/opendxl-virustotal-service-python/wiki/Service-Methods#url-scan>`__
 
 IP Address
 
-* `Report <https://github.com/opendxl/opendxl-virustotal-service-python/wiki/Service-Methods#ip-address-report>`_
+* `Report <https://github.com/opendxl/opendxl-virustotal-service-python/wiki/Service-Methods#ip-address-report>`__
 
 Domain
 
-* `Report <https://github.com/opendxl/opendxl-virustotal-service-python/wiki/Service-Methods#domain-report>`_
+* `Report <https://github.com/opendxl/opendxl-virustotal-service-python/wiki/Service-Methods#domain-report>`__
 
 Docker
 ------

--- a/doc/sdk/installation.rst
+++ b/doc/sdk/installation.rst
@@ -10,8 +10,8 @@ Prerequisites
 * The OpenDXL Python Client prerequisites must be satisfied
    `<https://opendxl.github.io/opendxl-client-python/pydoc/installation.html>`_
 
-* Python 2.7.9 or higher installed within a Windows or Linux environment
-   (Python 3 is not supported at this time)
+* Python 2.7.9 or higher in the Python 2.x series or Python 3.4.0 or higher
+  in the Python 3.x series installed within a Windows or Linux environment.
 
 * A valid VirusTotal API Key (See `VirusTotal Getting started <https://www.virustotal.com/en/documentation/public-api/#getting-started>`_ for more information)
    The API key must be specified in the :ref:`Service Configuration File <dxl_service_config_file_label>`
@@ -25,7 +25,7 @@ Use ``pip`` to automatically install the service library:
 
     .. parsed-literal::
 
-        pip install dxlvtapiservice-\ |version|\-py2.7-none-any.whl
+        pip install dxlvtapiservice-\ |version|\-py2.py3-none-any.whl
 
 Or with:
 

--- a/dxlvtapiservice/__main__.py
+++ b/dxlvtapiservice/__main__.py
@@ -25,7 +25,7 @@ def signal_handler(signum, frame):
     :param frame: The frame
     """
     del signum, frame
-    global running, run_condition
+    global running, run_condition  # pylint: disable=global-statement
     with run_condition:
         if running:
             # Stop the application
@@ -78,6 +78,6 @@ with VirusTotalApiService(sys.argv[1]) as app:
 
     except KeyboardInterrupt:
         pass
-    except:
+    except: # pylint: disable=bare-except
         logger.exception("Error occurred, exiting")
         sys.exit(1)

--- a/dxlvtapiservice/__main__.py
+++ b/dxlvtapiservice/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import logging
 from logging.config import fileConfig
 
@@ -38,7 +40,7 @@ signal.signal(signal.SIGINT, signal_handler)
 
 # Validate command line
 if len(sys.argv) != 2:
-    print "Usage: dxlvtapiservice <configuration files directory>"
+    print("Usage: dxlvtapiservice <configuration files directory>")
     sys.exit(1)
 
 #

--- a/dxlvtapiservice/app.py
+++ b/dxlvtapiservice/app.py
@@ -1,8 +1,9 @@
+from __future__ import absolute_import
 import logging
 
 from dxlbootstrap.app import Application
 from dxlclient.service import ServiceRegistrationInfo
-from requesthandlers import *
+from .requesthandlers import *
 
 
 # Configure local logger

--- a/dxlvtapiservice/app.py
+++ b/dxlvtapiservice/app.py
@@ -5,7 +5,6 @@ from dxlbootstrap.app import Application
 from dxlclient.service import ServiceRegistrationInfo
 from .requesthandlers import *
 
-
 # Configure local logger
 logger = logging.getLogger(__name__)
 
@@ -49,7 +48,8 @@ class VirusTotalApiService(Application):
         :param config_dir: The location of the configuration files for the
             application
         """
-        super(VirusTotalApiService, self).__init__(config_dir, "dxlvtapiservice.config")
+        super(VirusTotalApiService, self).__init__(config_dir,
+                                                   "dxlvtapiservice.config")
         self._api_key = None
 
     @property
@@ -93,12 +93,14 @@ class VirusTotalApiService(Application):
 
         # API Key
         try:
-            self._api_key = config.get(self.GENERAL_CONFIG_SECTION, self.GENERAL_API_KEY_CONFIG_PROP)
+            self._api_key = config.get(self.GENERAL_CONFIG_SECTION,
+                                       self.GENERAL_API_KEY_CONFIG_PROP)
         except Exception:
             pass
         if not self._api_key:
-            raise Exception("VirusTotal API Key not found in configuration file: {0}"
-                            .format(self._app_config_path))
+            raise Exception(
+                "VirusTotal API Key not found in configuration file: {0}"
+                .format(self._app_config_path))
 
     def on_dxl_connect(self):
         """
@@ -112,40 +114,44 @@ class VirusTotalApiService(Application):
         Invoked when services should be registered with the application
         """
         # Register service 'vtapiservice'
-        logger.info("Registering service: {0}".format("vtapiservice"))
+        logger.info("Registering service: %s", "vtapiservice")
         service = ServiceRegistrationInfo(self._dxl_client, self.SERVICE_TYPE)
 
-        logger.info("Registering request callback: {0}".format("file_rescan"))
+        logger.info("Registering request callback: %s", "file_rescan")
         self.add_request_callback(
             service, self.REQ_TOPIC_FILE_RESCAN,
             VirusTotalApiRequestCallback(
-                self, False, [VirusTotalApiRequestCallback.PARAM_RESOURCE]), False)
+                self, False, [VirusTotalApiRequestCallback.PARAM_RESOURCE]),
+            False)
 
-        logger.info("Registering request callback: {0}".format("file_report"))
+        logger.info("Registering request callback: %s", "file_report")
         self.add_request_callback(
             service, self.REQ_TOPIC_FILE_REPORT,
             VirusTotalApiRequestCallback(
-                self, True, [VirusTotalApiRequestCallback.PARAM_RESOURCE]), False)
+                self, True, [VirusTotalApiRequestCallback.PARAM_RESOURCE]),
+            False)
 
-        logger.info("Registering request callback: {0}".format("url_scan"))
+        logger.info("Registering request callback: %s", "url_scan")
         self.add_request_callback(
             service, self.REQ_TOPIC_URL_SCAN,
             VirusTotalApiRequestCallback(
                 self, False, [VirusTotalApiRequestCallback.PARAM_URL]), False)
 
-        logger.info("Registering request callback: {0}".format("url_report"))
+        logger.info("Registering request callback: %s", "url_report")
         self.add_request_callback(
             service, self.REQ_TOPIC_URL_REPORT,
             VirusTotalApiRequestCallback(
-                self, False, [VirusTotalApiRequestCallback.PARAM_RESOURCE]), False)
+                self, False, [VirusTotalApiRequestCallback.PARAM_RESOURCE]),
+            False)
 
-        logger.info("Registering request callback: {0}".format("ipaddress_report"))
+        logger.info(
+            "Registering request callback: %s", "ipaddress_report")
         self.add_request_callback(
             service, self.REQ_TOPIC_IP_ADDRESS_REPORT,
             VirusTotalApiRequestCallback(
                 self, True, [VirusTotalApiRequestCallback.PARAM_IP]), False)
 
-        logger.info("Registering request callback: {0}".format("domain_report"))
+        logger.info("Registering request callback: %s", "domain_report")
         self.add_request_callback(
             service, self.REQ_TOPIC_DOMAIN_REPORT,
             VirusTotalApiRequestCallback(

--- a/dxlvtapiservice/requesthandlers.py
+++ b/dxlvtapiservice/requesthandlers.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import logging
 import requests
 

--- a/dxlvtapiservice/requesthandlers.py
+++ b/dxlvtapiservice/requesthandlers.py
@@ -6,7 +6,6 @@ from dxlclient.callbacks import RequestCallback
 from dxlclient.message import Response, ErrorResponse
 from dxlbootstrap.util import MessageUtils
 
-
 # Configure local logger
 logger = logging.getLogger(__name__)
 
@@ -53,7 +52,8 @@ class VirusTotalApiRequestCallback(RequestCallback):
         if self._required_params:
             for param in self._required_params:
                 if param not in req_dict:
-                    raise Exception("Required parameter not specified: '{0}'".format(param))
+                    raise Exception(
+                        "Required parameter not specified: '{0}'".format(param))
 
     @staticmethod
     def _get_http_error_message(code):
@@ -63,10 +63,7 @@ class VirusTotalApiRequestCallback(RequestCallback):
         :param code: The HTTP response code
         :return: The error message for the response code
         """
-        if code is 204:
-            return "VirusTotal API request rate limit exceeded."
-        else:
-            return None
+        return "VirusTotal API request rate limit exceeded." if code == 204 else None
 
     def on_request(self, request):
         """
@@ -75,8 +72,10 @@ class VirusTotalApiRequestCallback(RequestCallback):
         :param request: The request message
         """
         # Handle request
-        logger.info("Request received on topic: '{0}' with payload: '{1}'".format(
-            request.destination_topic, MessageUtils.decode_payload(request)))
+        logger.info(
+            "Request received on topic: '%s' with payload: '%s'",
+            request.destination_topic,
+            MessageUtils.decode_payload(request))
 
         try:
             # API URL
@@ -92,9 +91,11 @@ class VirusTotalApiRequestCallback(RequestCallback):
 
             # Invoke VirusTotal API
             if self._is_get:
-                vtapi_response = requests.get(api_url, params=params, headers=self._headers)
+                vtapi_response = requests.get(api_url, params=params,
+                                              headers=self._headers)
             else:
-                vtapi_response = requests.post(api_url, params=params, headers=self._headers)
+                vtapi_response = requests.post(api_url, params=params,
+                                               headers=self._headers)
 
             # Check HTTP response code
             status_code = vtapi_response.status_code
@@ -102,9 +103,13 @@ class VirusTotalApiRequestCallback(RequestCallback):
                 vtapi_response.raise_for_status()
                 http_message = self._get_http_error_message(status_code)
                 if http_message:
-                    raise Exception("VirusTotal error, {0} ({1})".format(http_message, str(status_code)))
+                    raise Exception(
+                        "VirusTotal error, {0} ({1})".format(http_message,
+                                                             str(status_code)))
                 else:
-                    raise Exception("VirusTotal error, HTTP response code: {0}".format(status_code))
+                    raise Exception(
+                        "VirusTotal error, HTTP response code: {0}".format(
+                            status_code))
 
             # Create response
             res = Response(request)
@@ -119,5 +124,6 @@ class VirusTotalApiRequestCallback(RequestCallback):
             logger.exception("Error handling request")
             err_message = str(ex)
             err_message = err_message.replace(self._app.api_key, "--api-key--")
-            err_res = ErrorResponse(request, error_message=MessageUtils.encode(err_message))
+            err_res = ErrorResponse(request, error_message=MessageUtils.encode(
+                err_message))
             self._app.client.send_response(err_res)

--- a/sample/basic/basic_domain_report_example.py
+++ b/sample/basic/basic_domain_report_example.py
@@ -9,7 +9,7 @@ import sys
 
 from dxlclient.client_config import DxlClientConfig
 from dxlclient.client import DxlClient
-from dxlclient.message import Message, Event, Request
+from dxlclient.message import Message, Request
 from dxlbootstrap.util import MessageUtils
 
 # Import common logging and configuration

--- a/sample/basic/basic_domain_report_example.py
+++ b/sample/basic/basic_domain_report_example.py
@@ -2,6 +2,8 @@
 #
 # See: https://www.virustotal.com/en/documentation/public-api/#getting-domain-reports
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
 
@@ -38,7 +40,7 @@ with DxlClient(config) as client:
     if res.message_type != Message.MESSAGE_TYPE_ERROR:
         # Display results
         res_dict = MessageUtils.json_payload_to_dict(res)
-        print MessageUtils.dict_to_json(res_dict, pretty_print=True)
+        print(MessageUtils.dict_to_json(res_dict, pretty_print=True))
     else:
-        print "Error invoking service with topic '{0}': {1} ({2})".format(
-            request_topic, res.error_message, res.error_code)
+        print("Error invoking service with topic '{0}': {1} ({2})".format(
+            request_topic, res.error_message, res.error_code))

--- a/sample/basic/basic_file_report_example.py
+++ b/sample/basic/basic_file_report_example.py
@@ -9,7 +9,7 @@ import sys
 
 from dxlclient.client_config import DxlClientConfig
 from dxlclient.client import DxlClient
-from dxlclient.message import Message, Event, Request
+from dxlclient.message import Message, Request
 from dxlbootstrap.util import MessageUtils
 
 # Import common logging and configuration

--- a/sample/basic/basic_file_report_example.py
+++ b/sample/basic/basic_file_report_example.py
@@ -2,6 +2,8 @@
 #
 # See: https://www.virustotal.com/en/documentation/public-api/#getting-file-scans
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
 
@@ -38,7 +40,7 @@ with DxlClient(config) as client:
     if res.message_type != Message.MESSAGE_TYPE_ERROR:
         # Display results
         res_dict = MessageUtils.json_payload_to_dict(res)
-        print MessageUtils.dict_to_json(res_dict, pretty_print=True)
+        print(MessageUtils.dict_to_json(res_dict, pretty_print=True))
     else:
-        print "Error invoking service with topic '{0}': {1} ({2})".format(
-            request_topic, res.error_message, res.error_code)
+        print("Error invoking service with topic '{0}': {1} ({2})".format(
+            request_topic, res.error_message, res.error_code))

--- a/sample/basic/basic_file_rescan_example.py
+++ b/sample/basic/basic_file_rescan_example.py
@@ -9,7 +9,7 @@ import sys
 
 from dxlclient.client_config import DxlClientConfig
 from dxlclient.client import DxlClient
-from dxlclient.message import Message, Event, Request
+from dxlclient.message import Message, Request
 from dxlbootstrap.util import MessageUtils
 
 # Import common logging and configuration

--- a/sample/basic/basic_file_rescan_example.py
+++ b/sample/basic/basic_file_rescan_example.py
@@ -2,6 +2,8 @@
 #
 # See: https://www.virustotal.com/en/documentation/public-api/#rescanning-files
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
 
@@ -38,7 +40,7 @@ with DxlClient(config) as client:
     if res.message_type != Message.MESSAGE_TYPE_ERROR:
         # Display results
         res_dict = MessageUtils.json_payload_to_dict(res)
-        print MessageUtils.dict_to_json(res_dict, pretty_print=True)
+        print(MessageUtils.dict_to_json(res_dict, pretty_print=True))
     else:
-        print "Error invoking service with topic '{0}': {1} ({2})".format(
-            request_topic, res.error_message, res.error_code)
+        print("Error invoking service with topic '{0}': {1} ({2})".format(
+            request_topic, res.error_message, res.error_code))

--- a/sample/basic/basic_ip_address_report_example.py
+++ b/sample/basic/basic_ip_address_report_example.py
@@ -2,6 +2,8 @@
 #
 # See: https://www.virustotal.com/en/documentation/public-api/#getting-ip-reports
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
 
@@ -38,7 +40,7 @@ with DxlClient(config) as client:
     if res.message_type != Message.MESSAGE_TYPE_ERROR:
         # Display results
         res_dict = MessageUtils.json_payload_to_dict(res)
-        print MessageUtils.dict_to_json(res_dict, pretty_print=True)
+        print(MessageUtils.dict_to_json(res_dict, pretty_print=True))
     else:
-        print "Error invoking service with topic '{0}': {1} ({2})".format(
-            request_topic, res.error_message, res.error_code)
+        print("Error invoking service with topic '{0}': {1} ({2})".format(
+            request_topic, res.error_message, res.error_code))

--- a/sample/basic/basic_ip_address_report_example.py
+++ b/sample/basic/basic_ip_address_report_example.py
@@ -9,7 +9,7 @@ import sys
 
 from dxlclient.client_config import DxlClientConfig
 from dxlclient.client import DxlClient
-from dxlclient.message import Message, Event, Request
+from dxlclient.message import Message, Request
 from dxlbootstrap.util import MessageUtils
 
 # Import common logging and configuration

--- a/sample/basic/basic_url_report_example.py
+++ b/sample/basic/basic_url_report_example.py
@@ -9,7 +9,7 @@ import sys
 
 from dxlclient.client_config import DxlClientConfig
 from dxlclient.client import DxlClient
-from dxlclient.message import Message, Event, Request
+from dxlclient.message import Message, Request
 from dxlbootstrap.util import MessageUtils
 
 # Import common logging and configuration

--- a/sample/basic/basic_url_report_example.py
+++ b/sample/basic/basic_url_report_example.py
@@ -2,6 +2,8 @@
 #
 # See: https://www.virustotal.com/en/documentation/public-api/#getting-url-scans
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
 
@@ -38,7 +40,7 @@ with DxlClient(config) as client:
     if res.message_type != Message.MESSAGE_TYPE_ERROR:
         # Display results
         res_dict = MessageUtils.json_payload_to_dict(res)
-        print MessageUtils.dict_to_json(res_dict, pretty_print=True)
+        print(MessageUtils.dict_to_json(res_dict, pretty_print=True))
     else:
-        print "Error invoking service with topic '{0}': {1} ({2})".format(
-            request_topic, res.error_message, res.error_code)
+        print("Error invoking service with topic '{0}': {1} ({2})".format(
+            request_topic, res.error_message, res.error_code))

--- a/sample/basic/basic_url_scan_example.py
+++ b/sample/basic/basic_url_scan_example.py
@@ -9,7 +9,7 @@ import sys
 
 from dxlclient.client_config import DxlClientConfig
 from dxlclient.client import DxlClient
-from dxlclient.message import Message, Event, Request
+from dxlclient.message import Message, Request
 from dxlbootstrap.util import MessageUtils
 
 # Import common logging and configuration

--- a/sample/basic/basic_url_scan_example.py
+++ b/sample/basic/basic_url_scan_example.py
@@ -2,6 +2,8 @@
 #
 # See: https://www.virustotal.com/en/documentation/public-api/#scanning-urls
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
 
@@ -38,7 +40,7 @@ with DxlClient(config) as client:
     if res.message_type != Message.MESSAGE_TYPE_ERROR:
         # Display results
         res_dict = MessageUtils.json_payload_to_dict(res)
-        print MessageUtils.dict_to_json(res_dict, pretty_print=True)
+        print(MessageUtils.dict_to_json(res_dict, pretty_print=True))
     else:
-        print "Error invoking service with topic '{0}': {1} ({2})".format(
-            request_topic, res.error_message, res.error_code)
+        print("Error invoking service with topic '{0}': {1} ({2})".format(
+            request_topic, res.error_message, res.error_code))

--- a/sample/common.py
+++ b/sample/common.py
@@ -4,6 +4,7 @@ This includes the defining the path to the configuration file used to initialize
 in addition to setting up the logger appropriately.
 """
 
+from __future__ import absolute_import
 import os
 import logging
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 
 from setuptools import setup

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,63 @@
+# pylint: disable=no-member, no-name-in-module, import-error
+
 from __future__ import absolute_import
+import glob
 import os
-
-from setuptools import setup
 import distutils.command.sdist
-
+import distutils.log
+import subprocess
+from setuptools import Command, setup
 import setuptools.command.sdist
 
 # Patch setuptools' sdist behaviour with distutils' sdist behaviour
 setuptools.command.sdist.sdist.run = distutils.command.sdist.sdist.run
 
-version_info = {}
-cwd=os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(cwd, "dxlvtapiservice", "_version.py")) as f:
-    exec(f.read(), version_info)
+VERSION_INFO = {}
+CWD = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(CWD, "dxlvtapiservice", "_version.py")) as f:
+    exec(f.read(), VERSION_INFO)  # pylint: disable=exec-used
 
-dist = setup(
+
+class LintCommand(Command):
+    """
+    Custom setuptools command for running lint
+    """
+    description = 'run lint against project source files'
+    user_options = []
+    def initialize_options(self):
+        pass
+    def finalize_options(self):
+        pass
+    def run(self):
+        self.announce("Running pylint for library source files and tests",
+                      level=distutils.log.INFO)
+        subprocess.check_call(["pylint", "dxlvtapiservice"] + glob.glob("*.py"))
+
+
+class CiCommand(Command):
+    """
+    Custom setuptools command for running steps that are performed during
+    Continuous Integration testing.
+    """
+    description = 'run CI steps (lint, test, etc.)'
+    user_options = []
+    def initialize_options(self):
+        pass
+    def finalize_options(self):
+        pass
+    def run(self):
+        self.run_command("lint")
+
+TEST_REQUIREMENTS = ["pylint"]
+
+DEV_REQUIREMENTS = TEST_REQUIREMENTS + ["sphinx"]
+
+setup(
     # Package name:
     name="dxlvtapiservice",
 
     # Version number:
-    version=version_info["__version__"],
+    version=VERSION_INFO["__version__"],
 
     # Requirements
     install_requires=[
@@ -27,6 +65,13 @@ dist = setup(
         "dxlbootstrap>=0.1.3",
         "dxlclient"
     ],
+
+    tests_require=TEST_REQUIREMENTS,
+
+    extras_require={
+        "dev": DEV_REQUIREMENTS,
+        "test": TEST_REQUIREMENTS
+    },
 
     # Package author details:
     author="McAfee LLC",
@@ -49,7 +94,7 @@ dist = setup(
         "dxlvtapiservice._config.app" : ['*']},
 
     # Details
-    url="http://www.mcafee.com/",
+    url="http://www.mcafee.com",
 
     description="VirusTotal API DXL service library",
 
@@ -60,6 +105,16 @@ dist = setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6"
     ],
+
+    cmdclass={
+        "ci": CiCommand,
+        "lint": LintCommand
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,8 @@ setup(
 
     long_description=open('README').read(),
 
+    python_requires='>=2.7.9,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+
     classifiers=[
         "Development Status :: 4 - Beta",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,8 @@ setup(
     # Requirements
     install_requires=[
         "requests",
-        "dxlbootstrap>=0.1.3",
-        "dxlclient"
+        "dxlbootstrap>=0.2.0",
+        "dxlclient>=4.1.0.184"
     ],
 
     tests_require=TEST_REQUIREMENTS,

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,10 @@ class LintCommand(Command):
         self.announce("Running pylint for library source files and tests",
                       level=distutils.log.INFO)
         subprocess.check_call(["pylint", "dxlvtapiservice"] + glob.glob("*.py"))
+        self.announce("Running pylint for samples", level=distutils.log.INFO)
+        subprocess.check_call(["pylint"] + glob.glob("sample/*.py") +
+                              glob.glob("sample/**/*.py") +
+                              ["--rcfile", ".pylintrc.samples"])
 
 
 class CiCommand(Command):


### PR DESCRIPTION
This PR adds support for running under Python 3.4+, while retaining the ability to run under Python 2.7.

This PR is dependent upon releases of the OpenDXL Python client and bootstrap packages which support Python 3.4+, which is being added in https://github.com/opendxl/opendxl-client-python/pull/26 and https://github.com/opendxl/opendxl-bootstrap-python/pull/3, respectively. The Travis CI configuration temporarily depends upon branches of the OpenDXL Python client and bootstrap packages which support Python 3. The reference to the branches can be removed when Python 3-capable client and bootstrap releases is available.

Notable changes include:

* Package could be installed/used with Python 3.4+. Changes have been tested up to Python 3.6.4.
* A [universal wheel](https://packaging.python.org/tutorials/distributing-packages/#universal-wheels) package (single package which can be installed on either Python 2.7.9+ or Python 3.4.0+) will be built instead of a version-specific package.
* Package zip files will no longer include .egg files. These would need to be built uniquely per Python version - e.g., 2.7 vs. 3.4, 3.5, and 3.6.
* CI testing in Travis now includes running pylint against project sources and samples to help ensure version compatibility. The Travis CI build matrix now includes Python 2.7, 3.4, 3.5, and 3.6.